### PR TITLE
isActiveAndEnabled check before setting visibility

### DIFF
--- a/Assets/AniInstancing/Scripts/AnimationInstancingMgr.cs
+++ b/Assets/AniInstancing/Scripts/AnimationInstancingMgr.cs
@@ -933,7 +933,10 @@ namespace AnimationInstancing
             if (evt.hasBecomeVisible)
             {
                 Debug.Assert(evt.index < aniInstancingList.Count);
-                aniInstancingList[evt.index].visible = true;
+                if (aniInstancingList[evt.index].isActiveAndEnabled)
+                {
+                    aniInstancingList[evt.index].visible = true;
+                }
             }
             if (evt.hasBecomeInvisible)
             {


### PR DESCRIPTION
When enabling/disabling objects AnimationInstancingMgr will sometimes set visible=true for a disabled AnimationInstancing GameObject. This is more likely to happen when the GameObject is off-camera (culled).